### PR TITLE
bugfix for usage in List: fix firing all menu button's actions (in on…

### DIFF
--- a/Sources/SwipeCellSUI/SwipeCellSUI.swift
+++ b/Sources/SwipeCellSUI/SwipeCellSUI.swift
@@ -65,7 +65,7 @@ public struct SwipeCellModifier: ViewModifier {
                                 }
                             } label: {
                                 self.buttonContentView(item: item, group: swipeItemGroup, side: side)
-                            }
+                            }.buttonStyle(BorderlessButtonStyle())
 
                         }
                     }


### PR DESCRIPTION
Hello Dominik, thank you for your project, I love it!

I use it in ScrollViews and it works like a charm!

Recently I've added the swipeCells also into some Lists and found a bug - whenever I tap on one menu button - actions for all buttons in that row are fired. I think it's the same bug you've mentioned in section _Known issues_ of README.

I've found an easy way to "divide" the menu buttons (in one row) into separate buttons - each menu button now fires only one action.