### PR TITLE
Fix the issue where using .swipeCell() on the list item in iPhone XS Max causes the SwipeCellActionItem not fully displayed

### DIFF
--- a/Sources/SwipeCellSUI/SwipeCellSUI.swift
+++ b/Sources/SwipeCellSUI/SwipeCellSUI.swift
@@ -32,7 +32,7 @@ public struct SwipeCellModifier: ViewModifier {
                     .offset(x: self.offsetX)
                     .gesture(DragGesture(minimumDistance: 30, coordinateSpace: .local).onChanged(self.dragOnChanged(value:)).onEnded(dragOnEnded(value:)))
                     
-            }.frame(width: cellWidth)
+            }
             .edgesIgnoringSafeArea(.horizontal)
             .clipped()
             .onChange(of: self.currentUserInteractionCellID) { (_) in


### PR DESCRIPTION
I have been using SwipeCellSUI on most iPhone devices without any issues, except for the **iPhone XS Max**. 

As shown in the images below, the right side of the list item is cut off and `SwipeCellActionItem` is not fully displayed. After some experiments, I found that if I remove the `.frame(width: cellWidth)`, the list item seems to automatically adapt to the screen width. 

<img src="https://github.com/user-attachments/assets/8ca5858e-35fc-42a1-9282-0df59dba3660" width="300" />
<img src="https://github.com/user-attachments/assets/0860c6f8-8d18-42cf-aaa6-eb1fef3fd122" width="300" />

It appears that specifying a width is not necessary, allowing the `SwipeCellActionItem` to be fully displayed on most iPhones, including the **iPhone XS Max**. Could you please let me know if it’s possible to remove this line or share any other insights? Thank you!

### The images below are modified in iPhone XS Max:
<img src="https://github.com/user-attachments/assets/e60aeda6-833c-494c-ad75-6bc5a448bad9" width="300" />
<img src="https://github.com/user-attachments/assets/c9c60203-d086-4a04-b9b6-8675e639d237" width="300" />

### Code for testing:
```swift
import SwiftUI
import SwipeCellSUI

struct ContentView: View {
    @Binding var currentUserInteractionCellID: String?
    let items = Array(1...3)

    var body: some View {
        List(items.indices, id: \.self) { index in
            HStack {
                Text("Item \(index + 1)")
                    .frame(maxWidth: .infinity, alignment: .leading)
                    .contentShape(Rectangle())
                    .padding(.leading)
                Spacer()
                Text("footer")
            }
            .swipeCell(leadingSideGroup: [], trailingSideGroup: [
                SwipeCellActionItem(buttonView: {
                    ZStack {
                        Text("Button")
                            .foregroundColor(.white)
                            .fixedSize(horizontal: true, vertical: true)
                    }
                    .frame(maxHeight: .infinity)
                    .castToAnyView()
                }, backgroundColor: .blue, actionCallback: {
                    
                }),
            ], currentUserInteractionCellID: $currentUserInteractionCellID)
        }
        .listStyle(.inset)
    }
}

#Preview {
    ContentView(currentUserInteractionCellID: .constant(""))
}

```
